### PR TITLE
Remove relay.damus.io from default relays

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -191,7 +191,7 @@ export async function authCommand(options: AuthOptions): Promise<void> {
           name: 'relays',
           message: 'Enter relay URLs (comma-separated):',
           default:
-            'wss://relay.nostr.band,wss://nostrue.com,wss://relay.damus.io,wss://purplerelay.com,wss://relay.primal.net',
+            'wss://relay.nostr.band,wss://nostrue.com,wss://purplerelay.com,wss://relay.primal.net',
           filter: (input: string) => input.split(',').map((r) => r.trim()),
         },
       ]);

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -98,7 +98,7 @@ export async function configCommand(options: ConfigOptions): Promise<void> {
             message: 'Enter Nostr relay URLs (comma-separated):',
             default:
               currentConfig.nostr?.relays?.join(', ') ||
-              'wss://relay.nostr.band,wss://nostrue.com,wss://relay.damus.io,wss://purplerelay.com,wss://relay.primal.net',
+              'wss://relay.nostr.band,wss://nostrue.com,wss://purplerelay.com,wss://relay.primal.net',
             filter: (input: string) => input.split(',').map((r) => r.trim()),
             validate: (input: string[]) => {
               if (input.length === 0) return 'Please enter at least one relay URL';

--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -44,7 +44,6 @@ async function performAutoSetup(): Promise<void> {
         const defaultRelays = [
           'wss://relay.nostr.band',
           'wss://nostrue.com',
-          'wss://relay.damus.io',
           'wss://purplerelay.com',
           'wss://relay.primal.net',
         ];
@@ -93,7 +92,6 @@ async function performAutoSetup(): Promise<void> {
   const defaultRelays = [
     'wss://relay.nostr.band',
     'wss://nostrue.com',
-    'wss://relay.damus.io',
     'wss://purplerelay.com',
     'wss://relay.primal.net',
   ];


### PR DESCRIPTION
The damus relay has aggressive rate-limiting so it rejects the events most of the time.