### PR TITLE
Cut down on logs shown during deploy

### DIFF
--- a/src/commands/deploy.ts
+++ b/src/commands/deploy.ts
@@ -11,8 +11,6 @@ async function performAutoSetup(): Promise<void> {
   const config = await ConfigManager.getInstance();
   const nostr = new NostrManager();
 
-  console.log(chalk.cyan('\n🔐 Skip-setup mode: Checking for existing configuration...\n'));
-
   // Check if there's already local configuration
   const hasLocalConfig = await config.hasLocalConfig();
 
@@ -21,23 +19,7 @@ async function performAutoSetup(): Promise<void> {
 
     // Check if we have existing auth configuration (either private key or public key)
     if (userConfig.nostr?.publicKey || userConfig.nostr?.privateKey) {
-      console.log(chalk.green('✅ Found existing authentication configuration!'));
-
-      if (userConfig.nostr.privateKey) {
-        console.log(chalk.blue('🔑 Reusing existing private key for deployment'));
-        // Try to get the npub for display
-        try {
-          const npub = await nostr.getNpubSubdomain();
-          console.log(chalk.white('Public Key (npub): ') + chalk.blue(npub));
-        } catch (error) {
-          console.log(
-            chalk.yellow('⚠️  Could not display npub, but proceeding with existing keys')
-          );
-        }
-      } else if (userConfig.nostr.publicKey) {
-        console.log(chalk.blue('🔍 Reusing existing public key (read-only mode)'));
-        console.log(chalk.yellow('⚠️  Note: Public key only - cannot sign new deployments'));
-      }
+      console.log(chalk.green('✅ Using existing configuration'));
 
       // Still ensure other configuration is set up with defaults if missing
       if (!userConfig.nostr?.relays || userConfig.nostr.relays.length === 0) {
@@ -49,7 +31,6 @@ async function performAutoSetup(): Promise<void> {
           'wss://relay.primal.net',
         ];
         await config.setNostrRelays(defaultRelays);
-        console.log(chalk.green('✅ Set up default Nostr relays'));
       }
 
       if (!userConfig.blossom?.servers || userConfig.blossom.servers.length === 0) {
@@ -59,23 +40,18 @@ async function performAutoSetup(): Promise<void> {
           'https://blossom.band',
           'https://blossom.f7z.io',
         ]);
-        console.log(chalk.green('✅ Set up default Blossom servers'));
       }
 
       if (!userConfig.deployment?.baseDomain) {
         await config.setBaseDomain('nostrdeploy.com');
-        console.log(chalk.green('✅ Set up default base domain'));
       }
 
-      console.log(chalk.green('✅ Existing configuration ready for deployment!'));
       return;
     }
   }
 
   // No existing auth config found, generate new keypair
-  console.log(
-    chalk.yellow('⚡ No existing auth config found - auto-generating new Nostr keypair...\n')
-  );
+  console.log(chalk.yellow('⚡ Generating new Nostr keypair...'));
 
   // Generate new keypair
   const keyPair = nostr.generateKeyPair();
@@ -114,8 +90,6 @@ async function performAutoSetup(): Promise<void> {
   if (!userConfig.deployment?.baseDomain) {
     await config.setBaseDomain('nostrdeploy.com');
   }
-
-  console.log(chalk.green('✅ Auto-configuration complete!'));
 }
 
 export async function deployCommand(options: DeployOptions): Promise<void> {
@@ -126,12 +100,8 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
   try {
     console.log(chalk.cyan('\n🚀 Starting Deployment\n'));
 
-    const projectName = path.basename(process.cwd());
-    console.log(chalk.white('Project: ') + chalk.yellow(projectName));
-
     // Handle skip-setup flag
     if (options.skipSetup) {
-      console.log(chalk.yellow('⚡ Skip-setup mode enabled - auto-configuring...'));
       await performAutoSetup();
     } else {
       // Check if user is authenticated and configured
@@ -216,8 +186,6 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       return;
     }
 
-    console.log(chalk.blue(`📁 Using build directory: ${buildDir}`));
-
     // Validate build directory
     if (!(await fs.pathExists(buildDir))) {
       console.log(chalk.red(`❌ Build directory not found: ${buildDir}`));
@@ -249,7 +217,7 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       return;
     }
 
-    console.log(chalk.blue(`📄 Found ${files.length} files to deploy`));
+    console.log(chalk.blue(`📄 Deploying ${files.length} files from ${buildDir}`));
 
     // Start deployment
     spinner = ora('Preparing deployment...').start();
@@ -260,67 +228,9 @@ export async function deployCommand(options: DeployOptions): Promise<void> {
       spinner.succeed('Deployment completed successfully!');
 
       console.log(chalk.green('\n🎉 Deployment Successful!\n'));
-      console.log(chalk.white('Deployment Details:'));
       console.log(chalk.white('  🌐 URL: ') + chalk.cyan(`https://${result.fullUrl}`));
-      console.log(chalk.white('  🔑 NPub Subdomain: ') + chalk.blue(result.npubSubdomain));
-      console.log(chalk.white('  📅 Deployed: ') + chalk.gray(result.deployedAt.toLocaleString()));
       console.log(chalk.white('  📁 Files: ') + chalk.yellow(result.fileCount.toString()));
-
-      if (result.staticFileEventResults && result.staticFileEventResults.length > 0) {
-        console.log(chalk.white('  📡 Static File Events:'));
-        result.staticFileEventResults.forEach((eventResult, index: number) => {
-          console.log(
-            chalk.white(`    ${index + 1}. `) +
-              chalk.gray(eventResult.eventId.substring(0, 16) + '...')
-          );
-          // Show relay status for each event
-          const successCount = eventResult.relayResults.filter((r) => r.success).length;
-          const totalCount = eventResult.relayResults.length;
-          if (successCount === totalCount) {
-            console.log(chalk.white(`       ✅ Published to all ${totalCount} relays`));
-          } else {
-            console.log(
-              chalk.yellow(`       ⚠️  Published to ${successCount}/${totalCount} relays`)
-            );
-            eventResult.relayResults.forEach((result) => {
-              if (!result.success) {
-                console.log(chalk.red(`         ❌ ${result.relay}: ${result.error}`));
-              }
-            });
-          }
-        });
-      }
-
-      if (result.userServersEventResult) {
-        console.log(
-          chalk.white('  🌸 User Servers Event: ') +
-            chalk.gray(result.userServersEventResult.eventId.substring(0, 16) + '...')
-        );
-        // Show relay status for user servers event
-        const successCount = result.userServersEventResult.relayResults.filter(
-          (r) => r.success
-        ).length;
-        const totalCount = result.userServersEventResult.relayResults.length;
-        if (successCount === totalCount) {
-          console.log(chalk.white(`       ✅ Published to all ${totalCount} relays`));
-        } else {
-          console.log(chalk.yellow(`       ⚠️  Published to ${successCount}/${totalCount} relays`));
-          result.userServersEventResult.relayResults.forEach((result) => {
-            if (!result.success) {
-              console.log(chalk.red(`         ❌ ${result.relay}: ${result.error}`));
-            }
-          });
-        }
-      }
-
-      console.log(chalk.cyan('\n📖 About this deployment:'));
-      console.log(
-        chalk.white('Your site is deployed using the Pubkey Static Websites NIP standard.')
-      );
-      console.log(
-        chalk.white('Each file is published as a kind 34128 event with path and hash information.')
-      );
-      console.log(chalk.white('Your npub serves as your unique subdomain identifier.'));
+      console.log(chalk.white('  📅 Deployed: ') + chalk.gray(result.deployedAt.toLocaleString()));
 
       // Exit successfully after deployment
       process.exit(0);

--- a/src/utils/blossom.ts
+++ b/src/utils/blossom.ts
@@ -358,27 +358,21 @@ export class BlossomManager {
       const relativePath = result.filename.replace(dirPath + '/', '').replace(dirPath + '\\', '');
       results[relativePath] = result;
 
-      // Log upload status for each file
-      if (result.hasSuccess) {
-        const successCount = result.serverResults.filter((r) => r.success).length;
-        const totalCount = result.serverResults.length;
-        if (successCount === totalCount) {
-          console.log(`  ✅ ${relativePath}: Uploaded to all ${totalCount} servers`);
-        } else {
-          console.log(`  ⚠️  ${relativePath}: Uploaded to ${successCount}/${totalCount} servers`);
-          result.serverResults.forEach((serverResult) => {
-            if (!serverResult.success) {
-              console.log(`     ❌ ${serverResult.server}: ${serverResult.error}`);
-            }
-          });
-        }
-      } else {
+      // Just track success/failure, don't log per-file details
+      if (!result.hasSuccess) {
         console.log(`  ❌ ${relativePath}: Failed to upload to any server`);
-        result.serverResults.forEach((serverResult) => {
-          console.log(`     ❌ ${serverResult.server}: ${serverResult.error}`);
-        });
       }
     });
+
+    // Show upload summary
+    const successfulFiles = uploadResults.filter(r => r.hasSuccess).length;
+    const failedFiles = uploadResults.length - successfulFiles;
+    
+    if (failedFiles === 0) {
+      console.log(`✅ Successfully uploaded all ${successfulFiles} files`);
+    } else {
+      console.log(`⚠️  Uploaded ${successfulFiles}/${uploadResults.length} files (${failedFiles} failed)`);
+    }
 
     return results;
   }

--- a/src/utils/deployment.ts
+++ b/src/utils/deployment.ts
@@ -38,22 +38,16 @@ export class DeploymentManager {
   }
 
   public async deployStaticSite(buildDirectory: string): Promise<DeploymentResult> {
-    console.log('🚀 Starting deployment process...');
-
     // Step 1: Validate build directory
     await this.validateBuildDirectory(buildDirectory);
 
     // Step 2: Get npub subdomain
-    console.log('🔑 Generating npub subdomain...');
     const npubSubdomain = await this.nostr.getNpubSubdomain();
-    console.log(`🌐 Subdomain: ${npubSubdomain}.nostrdeploy.com`);
 
     // Step 3: Upload files to Blossom servers
-    console.log('📤 Uploading files to Blossom servers...');
     const uploadResults = await this.blossom.uploadDirectory(buildDirectory);
 
     // Step 4: Create static file info for Nostr events
-    console.log('📋 Preparing static file events...');
     const staticFiles: StaticFileInfo[] = [];
 
     for (const [filePath, blossomResult] of Object.entries(uploadResults)) {
@@ -64,10 +58,6 @@ export class DeploymentManager {
           path: absolutePath,
           sha256: blossomResult.sha256,
         });
-      } else {
-        console.warn(
-          `⚠️  Skipping ${filePath} from Nostr events - failed to upload to any Blossom server`
-        );
       }
     }
 
@@ -101,14 +91,11 @@ export class DeploymentManager {
     }
 
     // Step 6: Publish to Nostr according to Pubkey Static Websites NIP
-    console.log('📡 Publishing to Nostr using Pubkey Static Websites NIP...');
     const nostrResult = await this.nostr.publishDeploymentMetadata({
       npubSubdomain,
       files: staticFiles,
       blossomServers,
     });
-
-    console.log('✅ Deployment completed successfully!');
 
     return {
       npubSubdomain,

--- a/src/utils/nostr.ts
+++ b/src/utils/nostr.ts
@@ -140,17 +140,11 @@ export class NostrManager {
       }
     });
 
-    // Log relay results for debugging
+    // Only log if no relays succeeded (critical error)
     const successCount = processedResults.filter((r) => r.success).length;
-    const totalCount = processedResults.length;
-
-    if (successCount < totalCount) {
-      console.log(`⚠️  Published to ${successCount}/${totalCount} relays`);
-      processedResults.forEach((result) => {
-        if (!result.success) {
-          console.log(`   ❌ ${result.relay}: ${result.error}`);
-        }
-      });
+    
+    if (successCount === 0) {
+      console.log(`❌ Failed to publish to any relays`);
     }
 
     // Check if at least one relay accepted the event
@@ -265,10 +259,7 @@ export class NostrManager {
       relayResults: { relay: string; success: boolean; error?: string }[];
     };
   }> {
-    console.log('📡 Publishing static file events (kind 34128)...');
     const staticFileEventResults = await this.publishStaticFileEvents(deploymentInfo.files);
-
-    console.log('📡 Publishing user servers event (kind 10063)...');
     const userServersEventResult = await this.publishUserServersEvent(
       deploymentInfo.blossomServers
     );


### PR DESCRIPTION
The amount of logging during deploy is problematic because it pollutes the AI context with too much information (also I think users want it to be simpler too). Now output looks like this:

```
🚀 Starting Deployment

📄 Deploying 4 files from ./build
⠋ Preparing deployment...📤 Uploading 4 files to 4 Blossom server(s)...
⠹ Preparing deployment...✅ Successfully uploaded all 4 files
✔ Deployment completed successfully!

🎉 Deployment Successful!

  🌐 URL: https://npub12d5xqkc0jshzkcgg5fu8dqda46mqr2kscdxt53auqmp74vj88r8sr5psgy.nostrdeploy.com
  📁 Files: 4
  📅 Deployed: 6/16/2025, 9:22:03 PM
```